### PR TITLE
Fixed 'unsigneg' typo in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build APK
         run: |
           ./gradlew :demo:assembleRelease
-          mv demo/build/outputs/apk/release/demo-release-unsigneg.apk demo/build/outputs/apk/release/demo-release.apk
+          mv demo/build/outputs/apk/release/demo-release-unsigned.apk demo/build/outputs/apk/release/demo-release.apk
       - name: Upload APK to release
         uses: softprops/action-gh-release@v2
         id: release


### PR DESCRIPTION
This should address the failed release workflows. See failed job below.

https://github.com/hrach/navigation-compose/actions/runs/9357915797/job/25758728483